### PR TITLE
Update libarchive to allow rugged to install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install 
       shared-mime-info \
       sqlite-devel \
       yamllint && \
+      dnf -y update libarchive && \
       dnf clean all && \
       rm -rf /var/cache/dnf
 


### PR DESCRIPTION
Otherwise you get:
cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd